### PR TITLE
Rule skips

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -20,3 +20,4 @@ jobs:
         with:
           directory: terraform/
           quiet: true
+          skip_check: CKV_AZURE_42,CKV_AZURE_110


### PR DESCRIPTION
Disabled Checkov scanning for rules that would normally be used in prod, but not necessary in examples